### PR TITLE
Add auto tagging and specific format for created release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,16 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+  categories:
+    - title: Breaking Changes 🛠
+      labels:
+        - Semver-Major
+        - breaking-change
+    - title: New Features 🎉
+      labels:
+        - Semver-Minor
+        - enhancement
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -1,0 +1,25 @@
+name: semver
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: '0'
+
+    - name: Bump version and push tag
+      uses: anothrNick/github-tag-action@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        WITH_V: true
+        DEFAULT_BUMP: none
+        RELEASE_BRANCHES: main
+        MAJOR_STRING_TOKEN: perf
+        MINOR_STRING_TOKEN: feat
+        PATCH_STRING_TOKEN: fix


### PR DESCRIPTION
## Summary
This PR adds:
* automatic creation of tags based on semantic release keywords (perf, feat, fix) via github workflow
  *  it creates a semver release/pre-release tag based on the merge commit
     * however, merge commits are deactivated on this repository (instead it utilizes fast forward merge)
     * based on that the tag is created using the semantic release keyword of the last commit message on a specific feature branch (when merged to main)
* release note formatting based on PR tags
  * for breaking changes (major release) use PR tags: `Semver-Major` or `breaking-change`
  * for new features (minor release) use PR tags: `Semver-Minor` or `enhancement`
  * if no or other tags are provided, changes will be listed in "Other changes" 