### PR TITLE
Fix github action to create automated tags

### DIFF
--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -14,7 +14,7 @@ jobs:
         fetch-depth: '0'
 
     - name: Bump version and push tag
-      uses: anothrNick/github-tag-action@v1
+      uses: anothrNick/github-tag-action@1.53.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         WITH_V: true


### PR DESCRIPTION
This PR adds a specific version for the github action which create tags automatically. This is due to a bug in the latest release of the action.