### PR TITLE
Improve client compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,11 @@ ETH-duties logs upcoming validator duties to the console in order to find the be
 
 | client | tested | compatible |
 |  --- |  --- | --- |
-| prysm | :x: | :question: |
+| prysm | :heavy_check_mark: | :heavy_check_mark: |
 | lighthouse | :heavy_check_mark: | :heavy_check_mark: |
 | teku | :heavy_check_mark: | :heavy_check_mark: |
-| nimbus | :heavy_check_mark: | :x: |
-| lodestar | :heavy_check_mark: | :x: |
+| nimbus | :heavy_check_mark: | :heavy_check_mark: |
+| lodestar | :heavy_check_mark: | :heavy_check_mark: |
 
 ## Configuration
 

--- a/duties/constants/program.py
+++ b/duties/constants/program.py
@@ -9,6 +9,7 @@ from helper.terminate import GracefulTerminator
 REQUEST_TIMEOUT = (3, 5)
 REQUEST_CONNECTION_ERROR_WAITING_TIME = 2
 REQUEST_READ_TIMEOUT_ERROR_WAITING_TIME = 5
+REQUEST_HEADER = {"Content-type": "application/json", "Accept": "text/plain"}
 PRINTER_TIME_FORMAT = "%M:%S"
 GRACEFUL_TERMINATOR = GracefulTerminator(
     floor(ARGUMENTS.mode_cicd_waiting_time / ARGUMENTS.interval)

--- a/duties/constants/program.py
+++ b/duties/constants/program.py
@@ -9,7 +9,7 @@ from helper.terminate import GracefulTerminator
 REQUEST_TIMEOUT = (3, 5)
 REQUEST_CONNECTION_ERROR_WAITING_TIME = 2
 REQUEST_READ_TIMEOUT_ERROR_WAITING_TIME = 5
-REQUEST_HEADER = {"Content-type": "application/json", "Accept": "text/plain"}
+REQUEST_HEADER = {"Content-type": "application/json", "Accept": "application/json"}
 PRINTER_TIME_FORMAT = "%M:%S"
 GRACEFUL_TERMINATOR = GracefulTerminator(
     floor(ARGUMENTS.mode_cicd_waiting_time / ARGUMENTS.interval)

--- a/duties/protocol/request.py
+++ b/duties/protocol/request.py
@@ -6,6 +6,7 @@ from itertools import chain
 from logging import getLogger
 from time import sleep
 from typing import Any, List
+from urllib.parse import urlencode
 
 from cli.arguments import ARGUMENTS
 from constants import json, logging, program
@@ -93,9 +94,10 @@ def __send_request(
                         headers=program.REQUEST_HEADER,
                     )
                 case CalldataType.PARAMETERS:
+                    payload = urlencode({"id": calldata}, safe=",")
                     response = get(
                         url=f"{ARGUMENTS.beacon_node}{endpoint}",
-                        params={"id": calldata},
+                        params=payload,
                         timeout=program.REQUEST_TIMEOUT,
                     )
                 case _:

--- a/duties/protocol/request.py
+++ b/duties/protocol/request.py
@@ -90,6 +90,7 @@ def __send_request(
                         url=f"{ARGUMENTS.beacon_node}{endpoint}",
                         data=calldata,
                         timeout=program.REQUEST_TIMEOUT,
+                        headers=program.REQUEST_HEADER,
                     )
                 case CalldataType.PARAMETERS:
                     response = get(
@@ -159,7 +160,8 @@ def __get_processed_calldata(
     calldata: str = ""
     match calldata_type:
         case CalldataType.REQUEST_DATA:
-            calldata = f"[{','.join(validator_chunk)}]"
+            calldata = ",".join(f'"{validator}"' for validator in validator_chunk)
+            calldata = f"[{calldata}]"
         case CalldataType.PARAMETERS:
             calldata = f"{','.join(validator_chunk)}"
         case _:

--- a/duties/protocol/request.py
+++ b/duties/protocol/request.py
@@ -94,10 +94,10 @@ def __send_request(
                         headers=program.REQUEST_HEADER,
                     )
                 case CalldataType.PARAMETERS:
-                    payload = urlencode({"id": calldata}, safe=",")
+                    parameters = urlencode({"id": calldata}, safe=",")
                     response = get(
                         url=f"{ARGUMENTS.beacon_node}{endpoint}",
-                        params=payload,
+                        params=parameters,
                         timeout=program.REQUEST_TIMEOUT,
                     )
                 case _:


### PR DESCRIPTION
/release

## Summary

Currently `eth-duties` only supports Teku and Lighthouse due to the fact the requests were not implemented following the official beacon api spec. This PR will add compatibility for:

* Nimbus
* Lodestar
* Prysm

## Note on Lodestar

I needed to add a specific change how requests are sent because Lodestar does not support URI percent-encoding currently. This was reported as [bug in the Lodestar github repository](https://github.com/ChainSafe/lodestar/issues/5403). If it will be added/fixed, I will adapt `eth-duties` as well (back to usage of percent-encoding for all requests).

### Update on Lodestar specifics
It turns out that Lodestar is the only client implementing percent-encoding correctly or using the right library for handling requests. The `,` is a reserved delimiting character which therefore should not be encoded. Fur further details please follow the discussion in the aforementioned issue in the Lodestar repository.

Closes #32  