### PR TITLE
Improve cicd modes for home stakers

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,13 @@ ETH-duties logs upcoming validator duties to the console in order to find the be
 
 * [Consensus client compatibility](#consensus-client-compatibility)
 * [Configuration](#configuration)
-  * [--mode](#--mode)
+  * [--mode](#mode)
+    * [What are relevant duties](#what-are-relevant-duties)
     * [cicd-exit](#cicd-exit)
     * [cicd-wait](#cicd-wait)
-    * [exit](#exit)
+    * [cicd-force-graceful-exit](#cicd-force-graceful-exit)
+  * [--mode-cicd-attestation-time and --mode-cicd-attestation-proportion](#mode-cicd-attestation-time-and-mode-cicd-attestation-proportion)
+  * [--validators](#validators)
 * [What to expect](#what-to-expect)
   * [Examples](#examples)
 * [Binary/Executable Compatibility](#binary-executable-compatibility)
@@ -48,25 +51,53 @@ Most of the available flags are self explanatory. However, some may not be that 
 
 For all available cli flags please call `eth-duties --help` (see usage examples for further details).
 
-### --mode
+### mode
 
-The default running mode of `eth-duties` is logging duties to the console (specified with value `log`). However, professional node operators might leverage the tool in their cicd pipelines to e.g. prevent an unintentional client update when your validator is right before proposing a block or part of the sync committee. This is where the different `cicd` modes come into play. You can make your deployment job dependent from the `eth-duties` job so that the deployment job will only run when `eth-duties` exits gracefully with `exit code 0`.
+The default running mode of `eth-duties` is logging duties to the console (specified with value `log`). However, professional node operators or advanced home stakers might leverage the tool in their cicd pipelines to e.g. prevent an unintentional client update when your validator is right before proposing a block or part of the sync committee. This is where the different `cicd` modes come into play. You can make your deployment job dependent from the `eth-duties` job so that the deployment job will only run when `eth-duties` exits gracefully with `exit code 0`. This documentation will not go into detail about advanced pipelines in gitlab or github. However, I will provide a separate `cicd-compose.yaml` (in docker folder) which may be adopted by home stakers.
 
-**Note** If you do not omit attestation duties with `--omit-attestation-duties` these are also considered as valid duties for the cicd modes.
+**Note** If you do not omit attestation duties with `--omit-attestation-duties` these are also considered as valid duties for the cicd modes. For a more fine granular setting on attestation duties please check the [chapter about --mode-cicd-attestation-time and --mode-cicd-attestation-proportion](#mode-cicd-attestation-time-and-mode-cicd-attestation-proportion)
+
+**Note** You can run the cicd modes also just like the logging mode and check when `eth-duty` exits. However, you will not be able to distinguish whether `eth-duties` exits with code `0` or `1`.
+
+#### What are relevant duties
+
+In the following sub chapters I will often refer to relevant duties. This is a short explanation. Relevant are:
+
+* validator is in current sync committee
+* validator is in next sync committee
+* validator will propose a block
+* x of y attestation duties (while y == number of validators monitored) need to be executed in less than a defined time threshold
+  * see [chapter about --mode-cicd-attestation-time and --mode-cicd-attestation-proportion](#mode-cicd-attestation-time-and-mode-cicd-attestation-proportion)
 
 #### cicd-exit
 
-This mode results in a one time check whether one of your supplied validators has an upcoming duty. If there is an upcoming duty the tool exits with `exit code 1`. If there is none the tool exits with `exit code 0`.
+This mode results in a one time check whether one of your supplied validators has an relevant upcoming duty. If there is one the tool exits with `exit code 1`. If there is none the tool exits with `exit code 0`.
 
 #### cicd-wait
 
-This mode results in an ongoing process (similar to the standard behavior) where `eth-duties` checks for upcoming duties until there is none. If there will be no upcoming duty the application exits with `exit code 0`. Compared to the standard logging behavior this process only runs for a certain amount of time (specified with flag `--mode-cicd-waiting-time` (default: 780 seconds, approx. 2 epochs)). If this timeframe ends, `eth-duties` exits with `exit code 1`.
+This mode results in an ongoing process (similar to the standard behavior) where `eth-duties` checks for relevant upcoming duties until there is none. If there will be no relevant upcoming duty the application exits with `exit code 0`. Compared to the standard logging behavior this process only runs for a certain amount of time (specified with flag `--mode-cicd-waiting-time` (default: 780 seconds, approx. 2 epochs)). If this timeframe ends, `eth-duties` exits with `exit code 1`.
 
 #### exit
 
 This mode results in an immediate graceful exit with `exit code 0` without checking for duties. The rationale behind this flag is the following: If your deployment job will not run because of upcoming duties but you need to force an update for whatever reason you can use the mode `exit`. I'm not an expert in github pipelines but in gitlab you can prefill environment variables when you start a pipeline manually via the web ui. This way you don't need to adapt your pipeline code but just restart a pipeline with the `exit` mode. In general how to setup your pipelines is out of scope of this documentation. For more information please check the respective platform documentation. For gitlab this would be [the following website](https://docs.gitlab.com/ee/ci/pipelines/index.html#prefill-variables-in-manual-pipelines).
 
-### --validators
+### mode-cicd-attestation-time and mode-cicd-attestation-proportion
+
+These flags can be specifically useful for home stakers with a small amount of validators while using any cicd mode (`cicd-exit` or `cicd-wait`). The idea is that a home staker with a small amount of validators most often handles attestation duties and it might be hard to figure out manually when to perform e.g. a client update so that you only miss the minimum amount of attestation duty rewards or even none. **It is important to note that upcoming sync-committee or block proposal duties are considered relevant in any way. This means `eth-duties` will always exits non-gracefully in mode `cicd-exit` and `cicd-wait` (when waiting threshold is reached) while one of these relevant duties is in the queue. In other words if your settings for monitoring attesation duties are matched it will get ignored when another relevant duty is in the queue.**
+
+In general both flags refer to the fact that `eth-duties` will exit gracefully when the defined proportion of attestion duties will be executed after the provided time threshold. Let's check an example to get a better understanding. We assume a home staker who runs 10 validators:
+
+* You want to exit `eth-duties` gracefully when 8/10 validator attestation duties need to be executed in 4 minutes or later:
+
+  ```bash
+  --mode cicd-wait --mode-cicd-attestation-time 240 --mode-cicd-attestation-proportion 0.8
+  ```
+
+For more clarity please check the `attestation-compose.yaml` within the docker folder.
+
+These new flags will be only useful until a certain threshold of monitored validators is reached. This is because the higher the number of validators monitored the smaller the probability that a defined proportion of validator attestation duties will happen at a specified time in the future or later. To be more precise let's consider you monitor 30 validators. If you set the new flags to `--mode-cicd-attestation-time 240 --mode-cicd-attestation-proportion 0.8` it might never happen that 80% of attestation duties need to be performed in 4 minutes or later. You could reduce the proportion or/and time value but at some point these will not bring any value for you. You need to test a little bit what could be a good setting for your setup.
+
+### validators
 
 This flag is self-explanatory in general but you need to respect the following separation rules:
 

--- a/README.md
+++ b/README.md
@@ -57,8 +57,6 @@ The default running mode of `eth-duties` is logging duties to the console (speci
 
 **Note** If you do not omit attestation duties with `--omit-attestation-duties` these are also considered as valid duties for the cicd modes. For a more fine granular setting on attestation duties please check the [chapter about --mode-cicd-attestation-time and --mode-cicd-attestation-proportion](#mode-cicd-attestation-time-and-mode-cicd-attestation-proportion)
 
-**Note** You can run the cicd modes also just like the logging mode and check when `eth-duty` exits. However, you will not be able to distinguish whether `eth-duties` exits with code `0` or `1`.
-
 #### What are relevant duties
 
 In the following sub chapters I will often refer to relevant duties. This is a short explanation. Relevant are:
@@ -77,9 +75,9 @@ This mode results in a one time check whether one of your supplied validators ha
 
 This mode results in an ongoing process (similar to the standard behavior) where `eth-duties` checks for relevant upcoming duties until there is none. If there will be no relevant upcoming duty the application exits with `exit code 0`. Compared to the standard logging behavior this process only runs for a certain amount of time (specified with flag `--mode-cicd-waiting-time` (default: 780 seconds, approx. 2 epochs)). If this timeframe ends, `eth-duties` exits with `exit code 1`.
 
-#### exit
+#### cicd-force-graceful-exit
 
-This mode results in an immediate graceful exit with `exit code 0` without checking for duties. The rationale behind this flag is the following: If your deployment job will not run because of upcoming duties but you need to force an update for whatever reason you can use the mode `exit`. I'm not an expert in github pipelines but in gitlab you can prefill environment variables when you start a pipeline manually via the web ui. This way you don't need to adapt your pipeline code but just restart a pipeline with the `exit` mode. In general how to setup your pipelines is out of scope of this documentation. For more information please check the respective platform documentation. For gitlab this would be [the following website](https://docs.gitlab.com/ee/ci/pipelines/index.html#prefill-variables-in-manual-pipelines).
+This mode results in an immediate graceful exit with `exit code 0` without checking for duties. The rationale behind this flag is the following: If your deployment job will not run because of upcoming duties but you need to force an update for whatever reason you can use the mode `cicd-force-graceful-exit`. I'm not an expert in github pipelines but in gitlab you can prefill environment variables when you start a pipeline manually via the web ui. This way you don't need to adapt your pipeline code but just restart a pipeline with the `cicd-force-graceful-exit` mode. In general how to setup your pipelines is out of scope of this documentation. For more information please check the respective platform documentation. For gitlab this would be [the following website](https://docs.gitlab.com/ee/ci/pipelines/index.html#prefill-variables-in-manual-pipelines).
 
 ### mode-cicd-attestation-time and mode-cicd-attestation-proportion
 

--- a/docker/attestation-compose.yaml
+++ b/docker/attestation-compose.yaml
@@ -1,0 +1,48 @@
+---
+# This is an example/template compose to add eth-duties to your client deployments.
+# It assumes that you created a docker network called 'ethereum'.
+# In this example, if you e.g. update the beacon node image tag, the beacon node
+# will only get updated when eth-duties exits gracefully.
+# In this example eth-duties exits gracefully when no sync-committee or block proposal
+# duties are in the queue and when 7 of 10 attestation duties (10 validators are monitored)
+# will be executed in 3 minutes or later.
+
+version: "3.9"
+name: "eth-duties-attestation-template"
+services:
+  eth-duties:
+    container_name: "eth-duties"
+    image: "tobiwo/eth-duties:<IMAGE_TAG>"
+    command:
+    - "--validators"
+    - "1,3,5,7,9,10,12,124,45346,366"
+    - "--beacon-node"
+    - "http://<NAME_OF_YOUR_BEACON_NODE_CONTAINER>:<PORT_OF_BEACON_API>"
+    - "--mode"
+    - "cicd-wait"
+    - "--mode-cicd-attestation-time"
+    - "180"
+    - "--mode-cicd-attestation-proportion"
+    - "0.7"
+    networks:
+      - "ethereum"
+
+  beacon-node:
+    image: "<IMAGE_PATH>:<IMAGE_TAG>"
+    container_name: "beacon-node"
+    command:
+      - "--..."
+    volumes:
+      - "<HOST_PATH>:<CONTAINER_PATH>"
+    stop_grace_period: "2m"
+    restart: "always"
+    depends_on:
+      eth-duties:
+        condition: "service_completed_successfully"
+    networks:
+      - "ethereum"
+
+networks:
+  ethereum:
+    external: true
+...

--- a/docker/cicd-compose.yaml
+++ b/docker/cicd-compose.yaml
@@ -1,0 +1,44 @@
+---
+# This is an example/template compose to add eth-duties to your client deployments.
+# It assumes that you created a docker network called 'ethereum'.
+# In this example, if you e.g. update the beacon node image tag, the beacon node
+# will only get updated when eth-duties exits gracefully.
+# In this example eth-duties exits gracefully when no sync-committee or block proposal
+# duties are in the queue.
+
+version: "3.9"
+name: "eth-duties-cicd-template"
+services:
+  eth-duties:
+    container_name: "eth-duties"
+    image: "tobiwo/eth-duties:<IMAGE_TAG>"
+    command:
+    - "--validators"
+    - "1,3,5,7,9,10,12,124,45346,366"
+    - "--beacon-node"
+    - "http://<NAME_OF_YOUR_BEACON_NODE_CONTAINER>:<PORT_OF_BEACON_API>"
+    - "--mode"
+    - "cicd-wait"
+    - "--omit-attestation-duties"
+    networks:
+      - "ethereum"
+
+  beacon-node:
+    image: "<IMAGE_PATH>:<IMAGE_TAG>"
+    container_name: "beacon-node"
+    command:
+      - "--..."
+    volumes:
+      - "<HOST_PATH>:<CONTAINER_PATH>"
+    stop_grace_period: "2m"
+    restart: "always"
+    depends_on:
+      eth-duties:
+        condition: "service_completed_successfully"
+    networks:
+      - "ethereum"
+
+networks:
+  ethereum:
+    external: true
+...

--- a/duties/cli/arguments.py
+++ b/duties/cli/arguments.py
@@ -78,7 +78,7 @@ def __get_raw_arguments() -> Namespace:
         "--mode",
         help=(
             "The mode which eth-duties will run with. "
-            "Values are 'log', 'cicd-exit', 'cicd-wait' or 'exit' (default: 'log')"
+            "Values are 'log', 'cicd-exit', 'cicd-wait' or 'cicd-force-graceful-exit' (default: 'log')"
         ),
         type=Mode,
         choices=Mode,
@@ -100,10 +100,10 @@ def __get_raw_arguments() -> Namespace:
         help=(
             "If a defined proportion of attestion duties is above the defined time threshold "
             "the application exits gracefully in any cicd-mode "
-            "(default 420 sec.)"
+            "(default 240 sec.)"
         ),
         action="store",
-        default=420,
+        default=240,
     )
     parser.add_argument(
         "--mode-cicd-attestation-proportion",
@@ -111,10 +111,10 @@ def __get_raw_arguments() -> Namespace:
         help=(
             "The proportion of attestation duties which needs to be above a defined "
             "time threshold to force the application to exit gracefully "
-            "(default 0.8)"
+            "(default 1)"
         ),
         action="store",
-        default=0.8,
+        default=1,
     )
     parser.add_argument(
         "--omit-attestation-duties",

--- a/duties/cli/types.py
+++ b/duties/cli/types.py
@@ -10,4 +10,4 @@ class Mode(Enum):
     LOG = "log"
     CICD_EXIT = "cicd-exit"
     CICD_WAIT = "cicd-wait"
-    EXIT_GRACEFULLY = "exit"
+    CICD_FORCE_GRACEFUL_EXIT = "cicd-force-graceful-exit"

--- a/duties/constants/logging.py
+++ b/duties/constants/logging.py
@@ -34,3 +34,9 @@ PUBKEY_IS_NOT_HEXADECIMAL_MESSAGE = "Pubkey 0x%s is not hexadecimal: %s"
 DUPLICATE_VALIDATORS_MESSAGE = (
     "Filtered duplicated validators with different identifiers: %s"
 )
+ACTIVATED_MODE_MESSAGE = "Started in mode: %s"
+PROPORTION_OF_ATTESTION_DUTIES_ABOVE_TIME_THRESHOLD_MESSAGE = (
+    "%s%% of attestation duties will be executed in %s sec. or later"
+)
+EXIT_CODE_MESSAGE = "Exiting with code: %d"
+EXIT_DUE_TO_MAX_WAITING_TIME_MESSAGE = "Reached max. waiting time for mode 'cicd-wait'"

--- a/duties/constants/program.py
+++ b/duties/constants/program.py
@@ -1,19 +1,11 @@
 """Defines program related constants
 """
 
-from math import floor
-
-from cli.arguments import ARGUMENTS
-from helper.terminate import GracefulTerminator
-
 REQUEST_TIMEOUT = (3, 5)
 REQUEST_CONNECTION_ERROR_WAITING_TIME = 2
 REQUEST_READ_TIMEOUT_ERROR_WAITING_TIME = 5
 REQUEST_HEADER = {"Content-type": "application/json", "Accept": "application/json"}
 PRINTER_TIME_FORMAT = "%M:%S"
-GRACEFUL_TERMINATOR = GracefulTerminator(
-    floor(ARGUMENTS.mode_cicd_waiting_time / ARGUMENTS.interval)
-)
 THRESHOLD_TO_INFORM_USER_FOR_WAITING_PERIOD = 5000
 NOT_ALLOWED_CHARACTERS_FOR_VALIDATOR_PARSING = [".", ","]
 NUMBER_OF_VALIDATORS_PER_REST_CALL = 1000

--- a/duties/fetcher/log.py
+++ b/duties/fetcher/log.py
@@ -21,16 +21,15 @@ def log_time_to_next_duties(validator_duties: List[ValidatorDuty]) -> None:
         validator_duties (List[ValidatorDuty]): List of validator duties
     """
     logger = getLogger(__name__)
+    print("")
     logger.info(logging.NEXT_INTERVAL_MESSAGE)
     if validator_duties:
-        for index, duty in enumerate(validator_duties):
+        for duty in validator_duties:
             now = time()
             seconds_to_next_duty = (
                 duty.slot * ethereum.SLOT_TIME + ethereum.GENESIS_TIME - now
             )
             logging_message = __create_logging_message(seconds_to_next_duty, duty)
-            if index == len(validator_duties) - 1:
-                logging_message += "\n"
             logger.info(logging_message)
     else:
         logger.info(logging.NO_UPCOMING_DUTIES_MESSAGE)

--- a/duties/helper/terminate.py
+++ b/duties/helper/terminate.py
@@ -6,8 +6,10 @@ from asyncio import all_tasks, create_task, current_task, gather, get_running_lo
 from sys import exit as sys_exit
 from typing import List
 
+from cli.arguments import ARGUMENTS
 from cli.types import Mode
-from fetcher.data_types import ValidatorDuty
+from fetcher.data_types import DutyType, ValidatorDuty
+from protocol.ethereum import get_time_to_duty
 
 
 class GracefulTerminator:
@@ -25,23 +27,28 @@ class GracefulTerminator:
                 getattr(signal, signal_name), lambda: create_task(self.__shutdown())
             )
 
-    def terminate_in_cicd_mode(
-        self, running_mode: Mode, duties: List[ValidatorDuty]
-    ) -> None:
+    async def __shutdown(self) -> None:
+        """Cancels the task and raises exception if user generated SIGINT or SIGTERM is detected"""
+        tasks = [task for task in all_tasks() if task is not current_task()]
+        for task in tasks:
+            task.cancel()
+        await gather(*tasks, return_exceptions=True)
+
+    def terminate_in_cicd_mode(self, duties: List[ValidatorDuty]) -> None:
         """Terminates the running application in dependence of the mode and
         the duties which could be found for the provided validators
 
         Args:
-            running_mode (Mode): Running mode of eth-duties
             duties (List[ValidatorDuty]): List of fetched validator duties
         """
+        running_mode: Mode = ARGUMENTS.mode
         match running_mode:
             case Mode.CICD_EXIT:
-                if len(duties) > 0:
-                    sys_exit(1)
-                sys_exit(0)
+                if self.__no_relevant_upcoming_duties(duties):
+                    sys_exit(0)
+                sys_exit(1)
             case Mode.CICD_WAIT:
-                if len(duties) == 0:
+                if self.__no_relevant_upcoming_duties(duties):
                     sys_exit(0)
                 if self.__cicd_cycle_counter >= self.__max_number_of_cicd_cycles:
                     sys_exit(1)
@@ -51,9 +58,59 @@ class GracefulTerminator:
                 pass
         self.__cicd_cycle_counter += 1
 
-    async def __shutdown(self) -> None:
-        """Cancels the task and raises exception if user generated SIGINT or SIGTERM is detected"""
-        tasks = [task for task in all_tasks() if task is not current_task()]
-        for task in tasks:
-            task.cancel()
-        await gather(*tasks, return_exceptions=True)
+    def __no_relevant_upcoming_duties(self, duties: List[ValidatorDuty]) -> bool:
+        """Checks whether there are non relevant upcoming duties for the provided validators
+
+        Args:
+            duties (List[ValidatorDuty]): List of fetched validator duties
+
+        Returns:
+            bool: Whether or not there are any relevant upcoming duties
+        """
+        if len(duties) == 0:
+            return True
+        attestation_duties = [
+            duty for duty in duties if duty.type == DutyType.ATTESTATION
+        ]
+        if len(attestation_duties) != len(duties):
+            return False
+        return self.__is_proportion_of_attestation_duties_above_time_threshold(
+            attestation_duties
+        )
+
+    def __is_proportion_of_attestation_duties_above_time_threshold(
+        self, attestation_duties: List[ValidatorDuty]
+    ) -> bool:
+        """Checks whether upcoming attestation duties will occur after a user definded
+        time threshold and thus be defined as non-relevant duties
+
+        Args:
+            duties (List[ValidatorDuty]): List of fetched validator duties
+
+        Returns:
+            bool: Whether or not there are any relevant upcoming attestation duties
+        """
+        attestion_duties_above_threshold = (
+            self.__get_attestation_duties_above_time_threshold(attestation_duties)
+        )
+        relevant_duty_proportion = len(attestion_duties_above_threshold) / len(
+            attestation_duties
+        )
+        return relevant_duty_proportion >= ARGUMENTS.mode_cicd_attestation_proportion
+
+    def __get_attestation_duties_above_time_threshold(
+        self, attestation_duties: List[ValidatorDuty]
+    ) -> List[ValidatorDuty]:
+        """Gets attestation duties above user defined time threshold
+
+        Args:
+            attestation_duties (List[ValidatorDuty]): List of fetched attestation duties
+
+        Returns:
+            List[ValidatorDuty]: Attestation duties above user defined time threshold
+        """
+        return [
+            duty
+            for duty in attestation_duties
+            if get_time_to_duty(duty) >= ARGUMENTS.mode_cicd_attestation_time
+        ]

--- a/duties/main.py
+++ b/duties/main.py
@@ -87,6 +87,7 @@ async def main() -> None:
 
 if __name__ == "__main__":
     main_logger = getLogger(__name__)
+    main_logger.info(logging.ACTIVATED_MODE_MESSAGE, ARGUMENTS.mode.value)
     try:
         run(main())
     except (CancelledError, KeyboardInterrupt) as exception:

--- a/duties/main.py
+++ b/duties/main.py
@@ -81,7 +81,7 @@ async def main() -> None:
     while True:
         upcoming_duties = await __fetch_validator_duties(upcoming_duties)
         log_time_to_next_duties(upcoming_duties)
-        graceful_terminator.terminate_in_cicd_mode(ARGUMENTS.mode, upcoming_duties)
+        graceful_terminator.terminate_in_cicd_mode(upcoming_duties)
         await sleep(ARGUMENTS.interval)
 
 

--- a/duties/protocol/ethereum.py
+++ b/duties/protocol/ethereum.py
@@ -7,6 +7,7 @@ from sys import exit as sys_exit
 from time import time
 
 from constants import endpoints, json, logging
+from fetcher.data_types import ValidatorDuty
 from protocol.request import CalldataType, send_beacon_api_request
 
 __LOGGER = getLogger()
@@ -53,3 +54,15 @@ def get_current_epoch() -> int:
     """
     now = time()
     return trunc((now - GENESIS_TIME) / (SLOTS_PER_EPOCH * SLOT_TIME))
+
+
+def get_time_to_duty(duty: ValidatorDuty) -> float:
+    """Calculates the time (seconds) left until provided duty needs to be sent
+
+    Args:
+        duty (ValidatorDuty): Validator duty
+
+    Returns:
+        float: Time in seconds
+    """
+    return duty.slot * SLOT_TIME + GENESIS_TIME - time()


### PR DESCRIPTION
/release

## Summary

This MR improves `cicd` modes so that it is possible to also consider attestation duties for deployment pipelines. This improvement is mainly suitable for home stakers with a low number of validators.

In particular the MR:

* adds flag `--mode-cicd-attestation-time`
* adds flag `--mode-cicd-attestation-proportion`
* renames mode `exit` to `cicd-force-graceful-exit`
* Add docker-compose examples for using cicd modes in docker setup

Please check the updated documentation (and the compose examples) for further explanation.

Closes #43 