### PR TITLE
Update logging verbosity

### DIFF
--- a/duties/constants/logging.py
+++ b/duties/constants/logging.py
@@ -32,8 +32,8 @@ DUPLICATE_VALIDATORS_MESSAGE = (
     "Filtered duplicated validators with different identifiers: %s"
 )
 ACTIVATED_MODE_MESSAGE = "Started in mode: %s"
-PROPORTION_OF_ATTESTION_DUTIES_ABOVE_TIME_THRESHOLD_MESSAGE = (
-    "%s%% of attestation duties will be executed in %s sec. or later"
+PROPORTION_OF_DUTIES_ABOVE_TIME_THRESHOLD_MESSAGE = (
+    "%s%% of %s duties will be executed in %s sec. or later"
 )
 EXIT_CODE_MESSAGE = "Exiting with code: %d"
 EXIT_DUE_TO_MAX_WAITING_TIME_MESSAGE = "Reached max. waiting time for mode 'cicd-wait'"

--- a/duties/fetcher/data_types.py
+++ b/duties/fetcher/data_types.py
@@ -26,7 +26,7 @@ class ValidatorDuty(BaseModel):
     slot: int = Field(default=0)
     validator_sync_committee_indices: List[int] = Field(default_factory=list)
     type: DutyType = Field(default=DutyType.NONE)
-    time_to_duty: int = Field(default=0)
+    seconds_to_duty: int = Field(default=0)
 
 
 @dataclass

--- a/duties/fetcher/log.py
+++ b/duties/fetcher/log.py
@@ -77,7 +77,7 @@ def __create_logging_message(duty: ValidatorDuty) -> str:
     """
     if duty.type is DutyType.SYNC_COMMITTEE:
         logging_message = __create_sync_committee_logging_message(duty)
-    elif duty.time_to_duty < 0:
+    elif duty.seconds_to_duty < 0:
         logging_message = (
             f"Upcoming {duty.type.name} duty "
             f"for validator {__get_validator_identifier_for_logging(duty)} outdated. "
@@ -86,10 +86,10 @@ def __create_logging_message(duty: ValidatorDuty) -> str:
     else:
         time_to_next_duty = strftime(
             program.DUTY_LOGGING_TIME_FORMAT,
-            gmtime(duty.time_to_duty),
+            gmtime(duty.seconds_to_duty),
         )
         logging_message = (
-            f"{__get_logging_color(duty.time_to_duty, duty)}"
+            f"{__get_logging_color(duty.seconds_to_duty, duty)}"
             f"Validator {__get_validator_identifier_for_logging(duty)} "
             f"has next {duty.type.name} duty in: "
             f"{time_to_next_duty} min. (slot: {duty.slot}){rs.all}"
@@ -113,7 +113,7 @@ def __create_sync_committee_logging_message(sync_committee_duty: ValidatorDuty) 
     time_to_next_sync_committee = __get_time_to_next_sync_committee(
         sync_committee_duty, current_sync_committee_epoch_boundaries
     )
-    if sync_committee_duty.time_to_duty == 0:
+    if sync_committee_duty.seconds_to_duty == 0:
         logging_message = (
             f"{bg.red}Validator {__get_validator_identifier_for_logging(sync_committee_duty)} "
             f"is in current sync committee (next sync committee starts in "
@@ -144,8 +144,8 @@ def __get_time_to_next_sync_committee(
     Returns:
         str: Time to next sync committee start
     """
-    if sync_committee_duty.time_to_duty > 0:
-        return timedelta(seconds=sync_committee_duty.time_to_duty)
+    if sync_committee_duty.seconds_to_duty > 0:
+        return timedelta(seconds=sync_committee_duty.seconds_to_duty)
     current_slot = ethereum.get_current_slot()
     return timedelta(
         seconds=ethereum.get_time_to_next_sync_committee(

--- a/duties/fetcher/log.py
+++ b/duties/fetcher/log.py
@@ -10,6 +10,7 @@ from cli.arguments import ARGUMENTS
 from constants import logging, program
 from fetcher.data_types import DutyType, ValidatorDuty, ValidatorIdentifier
 from fetcher.identifier.core import read_validator_identifiers_from_shared_memory
+from helper.help import get_duties_proportion_above_time_threshold
 from protocol import ethereum
 from sty import bg, rs  # type: ignore[import]
 
@@ -31,6 +32,7 @@ def log_time_to_next_duties(validator_duties: List[ValidatorDuty]) -> None:
         for duty in validator_duties:
             logging_message = __create_logging_message(duty)
             __LOGGER.info(logging_message)
+        __log_duty_proportion_above_time_threshold(validator_duties)
     else:
         __LOGGER.info(logging.NO_UPCOMING_DUTIES_MESSAGE)
 
@@ -41,6 +43,25 @@ def __set_global_validator_identifiers_with_alias() -> None:
     global __validator_identifiers_with_alias
     __validator_identifiers_with_alias = read_validator_identifiers_from_shared_memory(
         program.ACTIVE_VALIDATOR_IDENTIFIERS_WITH_ALIAS_SHARED_MEMORY_NAME
+    )
+
+
+def __log_duty_proportion_above_time_threshold(
+    validator_duties: List[ValidatorDuty],
+) -> None:
+    """Log the proportion of validator duties above a defined time threshold
+
+    Args:
+        validator_duties (List[ValidatorDuty]): List of validator duties
+    """
+    relevant_duty_proportion = get_duties_proportion_above_time_threshold(
+        validator_duties, ARGUMENTS.log_time_warning
+    )
+    __LOGGER.info(
+        logging.PROPORTION_OF_DUTIES_ABOVE_TIME_THRESHOLD_MESSAGE,
+        round(relevant_duty_proportion * 100, 2),
+        "all",
+        ARGUMENTS.log_time_warning,
     )
 
 

--- a/duties/helper/help.py
+++ b/duties/helper/help.py
@@ -151,7 +151,7 @@ def get_duties_proportion_above_time_threshold(
         float: Duties proportion above user defined time threshold
     """
     duties_above_threshold = [
-        duty for duty in duties if duty.time_to_duty >= time_threshold
+        duty for duty in duties if duty.seconds_to_duty >= time_threshold
     ]
     relevant_duty_proportion = len(duties_above_threshold) / len(duties)
     return relevant_duty_proportion

--- a/duties/helper/help.py
+++ b/duties/helper/help.py
@@ -139,4 +139,22 @@ async def fetch_upcoming_validator_duties() -> List[ValidatorDuty]:
     return duties
 
 
+def get_duties_proportion_above_time_threshold(
+    duties: List[ValidatorDuty], time_threshold: int
+) -> float:
+    """Get duties proportion above user defined time threshold
+
+    Args:
+        duties (List[ValidatorDuty]): List of fetched duties
+
+    Returns:
+        float: Duties proportion above user defined time threshold
+    """
+    duties_above_threshold = [
+        duty for duty in duties if duty.time_to_duty >= time_threshold
+    ]
+    relevant_duty_proportion = len(duties_above_threshold) / len(duties)
+    return relevant_duty_proportion
+
+
 __sort_duties: Callable[[ValidatorDuty], int] = lambda duty: duty.slot

--- a/duties/helper/terminate.py
+++ b/duties/helper/terminate.py
@@ -11,7 +11,7 @@ from cli.arguments import ARGUMENTS
 from cli.types import Mode
 from constants import logging
 from fetcher.data_types import DutyType, ValidatorDuty
-from helper.help import clean_shared_memory
+from helper.help import clean_shared_memory, get_duties_proportion_above_time_threshold
 
 
 class GracefulTerminator:
@@ -103,32 +103,13 @@ class GracefulTerminator:
         Returns:
             bool: Whether or not there are any relevant upcoming attestation duties
         """
-        attestion_duties_above_threshold = (
-            self.__get_attestation_duties_above_time_threshold(attestation_duties)
-        )
-        relevant_duty_proportion = len(attestion_duties_above_threshold) / len(
-            attestation_duties
+        relevant_duty_proportion = get_duties_proportion_above_time_threshold(
+            attestation_duties, ARGUMENTS.mode_cicd_attestation_time
         )
         self.logger.info(
-            logging.PROPORTION_OF_ATTESTION_DUTIES_ABOVE_TIME_THRESHOLD_MESSAGE,
-            relevant_duty_proportion * 100,
+            logging.PROPORTION_OF_DUTIES_ABOVE_TIME_THRESHOLD_MESSAGE,
+            round(relevant_duty_proportion * 100, 2),
+            "attestation",
             ARGUMENTS.mode_cicd_attestation_time,
         )
         return relevant_duty_proportion >= ARGUMENTS.mode_cicd_attestation_proportion
-
-    def __get_attestation_duties_above_time_threshold(
-        self, attestation_duties: List[ValidatorDuty]
-    ) -> List[ValidatorDuty]:
-        """Gets attestation duties above user defined time threshold
-
-        Args:
-            attestation_duties (List[ValidatorDuty]): List of fetched attestation duties
-
-        Returns:
-            List[ValidatorDuty]: Attestation duties above user defined time threshold
-        """
-        return [
-            duty
-            for duty in attestation_duties
-            if duty.time_to_duty >= ARGUMENTS.mode_cicd_attestation_time
-        ]

--- a/duties/main.py
+++ b/duties/main.py
@@ -2,7 +2,7 @@
 """
 
 from asyncio import CancelledError, run, sleep
-from logging import getLogger
+from logging import Logger, getLogger
 from math import floor
 from platform import system
 from typing import List
@@ -72,7 +72,7 @@ async def __main() -> None:
             await sleep(ARGUMENTS.interval)
 
 
-def __start_processes(rest_server: RestServer) -> None:
+def __start_processes(rest_server: RestServer, logger: Logger) -> None:
     """Starts the relevant processes
 
     Args:
@@ -83,7 +83,7 @@ def __start_processes(rest_server: RestServer) -> None:
         rest_server.server.started = True
         run(__main())
     elif ARGUMENTS.rest and "cicd" in ARGUMENTS.mode.value:
-        main_logger.info(logging.IGNORED_REST_FLAG_MESSAGE)
+        logger.info(logging.IGNORED_REST_FLAG_MESSAGE)
         run(__main())
     else:
         run(__main())
@@ -94,7 +94,7 @@ if __name__ == "__main__":
     main_logger.info(logging.ACTIVATED_MODE_MESSAGE, ARGUMENTS.mode.value)
     rest_api_server = create_rest_server()
     try:
-        __start_processes(rest_api_server)
+        __start_processes(rest_api_server, main_logger)
     except (CancelledError, KeyboardInterrupt):
         if rest_api_server.server.started:
             rest_api_server.stop()

--- a/duties/protocol/ethereum.py
+++ b/duties/protocol/ethereum.py
@@ -77,13 +77,13 @@ def set_time_to_duty(duty: ValidatorDuty) -> None:
                 current_sync_committee_epoch_boundaries[1] + 1,
                 1,
             ):
-                duty.time_to_duty = 0
+                duty.seconds_to_duty = 0
             else:
-                duty.time_to_duty = get_time_to_next_sync_committee(
+                duty.seconds_to_duty = get_time_to_next_sync_committee(
                     current_sync_committee_epoch_boundaries, current_slot
                 )
         case _:
-            duty.time_to_duty = int(duty.slot * SLOT_TIME + GENESIS_TIME - time())
+            duty.seconds_to_duty = int(duty.slot * SLOT_TIME + GENESIS_TIME - time())
 
 
 def get_time_to_next_sync_committee(


### PR DESCRIPTION
## Summary

This PR adds/changes the following:

* Add general duty proportion logging based on the time set with `--log-time-warning`
* Fix a small bug that proportion values could have been printed with multiple decimal places
* Rename `time_to_duty` property of `ValidatorDuty` DTO to `seconds_to_duty` for better understanding especially while working with the RESTful api

Closes #53 