### PR TITLE
Implement concurrent api calls

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -67,18 +67,18 @@ jobs:
               mkdir /tmp/artifacts;
               cp ${BUILD_FILE_NAME}.tar.gz /tmp/artifacts;
               shasum -a 256 ${BUILD_FILE_NAME}.tar.gz | head -c 64 > /tmp/artifacts/${BUILD_FILE_NAME}.sha256
-          - OS: "windows-latest"
-            PYTHON_VERSION: "3.12.0"
-            BUILD_CMD: |
-              source $VENV
-              export PYTHONHASHSEED=42
-              export BUILD_FILE_NAME=eth-duties-${RELEASE_VERSION}-windows-amd64;
-              mkdir ${BUILD_FILE_NAME};
-              poetry run pyinstaller --clean --onefile --copy-metadata eth-typing --add-data "config;config" --name eth-duties --distpath ./${BUILD_FILE_NAME} ./duties/main.py;
-              tar -zcvf ${BUILD_FILE_NAME}.tar.gz ./${BUILD_FILE_NAME};
-              mkdir /tmp/artifacts;
-              cp ${BUILD_FILE_NAME}.tar.gz /tmp/artifacts;
-              sha256sum ${BUILD_FILE_NAME}.tar.gz | head -c 64 > /tmp/artifacts/${BUILD_FILE_NAME}.sha256;
+          # - OS: "windows-latest"
+          #   PYTHON_VERSION: "3.12.0"
+          #   BUILD_CMD: |
+          #     source $VENV
+          #     export PYTHONHASHSEED=42
+          #     export BUILD_FILE_NAME=eth-duties-${RELEASE_VERSION}-windows-amd64;
+          #     mkdir ${BUILD_FILE_NAME};
+          #     poetry run pyinstaller --clean --onefile --copy-metadata eth-typing --add-data "config;config" --name eth-duties --distpath ./${BUILD_FILE_NAME} ./duties/main.py;
+          #     tar -zcvf ${BUILD_FILE_NAME}.tar.gz ./${BUILD_FILE_NAME};
+          #     mkdir /tmp/artifacts;
+          #     cp ${BUILD_FILE_NAME}.tar.gz /tmp/artifacts;
+          #     sha256sum ${BUILD_FILE_NAME}.tar.gz | head -c 64 > /tmp/artifacts/${BUILD_FILE_NAME}.sha256;
     defaults:
       run:
         shell: "bash"
@@ -104,13 +104,13 @@ jobs:
         env:
           RELEASE_VERSION: "${{ steps.get_version.outputs.VERSION }}"
         run: "${{ matrix.BUILD_CMD }}"
-      - name: "Upload windows artifacts"
-        if: "matrix.OS == 'windows-latest'"
-        uses: "actions/upload-artifact@v3.1.3"
-        with:
-          name: "${{ matrix.OS }}"
-          path: "C:\\Users\\runneradmin\\AppData\\Local\\Temp\\artifacts\\*"
-          if-no-files-found: "error"
+      # - name: "Upload windows artifacts"
+      #   if: "matrix.OS == 'windows-latest'"
+      #   uses: "actions/upload-artifact@v3.1.3"
+      #   with:
+      #     name: "${{ matrix.OS }}"
+      #     path: "C:\\Users\\runneradmin\\AppData\\Local\\Temp\\artifacts\\*"
+      #     if-no-files-found: "error"
       - name: "Upload UNIX artifacts"
         if: "matrix.OS != 'windows-latest'"
         uses: "actions/upload-artifact@v3.1.3"
@@ -138,6 +138,8 @@ jobs:
         with:
           generate_release_notes: true
           fail_on_unmatched_files: true
+            # /tmp/artifacts/windows-latest/eth-duties-${{ steps.get_version.outputs.VERSION }}-windows-amd64.tar.gz
+            # /tmp/artifacts/windows-latest/eth-duties-${{ steps.get_version.outputs.VERSION }}-windows-amd64.sha256
           files: |
             /tmp/artifacts/ubuntu-22.04/eth-duties-${{ steps.get_version.outputs.VERSION }}-ubuntu2204-amd64.tar.gz
             /tmp/artifacts/ubuntu-22.04/eth-duties-${{ steps.get_version.outputs.VERSION }}-ubuntu2204-amd64.sha256
@@ -145,6 +147,4 @@ jobs:
             /tmp/artifacts/ubuntu-20.04/eth-duties-${{ steps.get_version.outputs.VERSION }}-ubuntu2004-amd64.sha256
             /tmp/artifacts/macos-latest/eth-duties-${{ steps.get_version.outputs.VERSION }}-darwin-amd64.tar.gz
             /tmp/artifacts/macos-latest/eth-duties-${{ steps.get_version.outputs.VERSION }}-darwin-amd64.sha256
-            /tmp/artifacts/windows-latest/eth-duties-${{ steps.get_version.outputs.VERSION }}-windows-amd64.tar.gz
-            /tmp/artifacts/windows-latest/eth-duties-${{ steps.get_version.outputs.VERSION }}-windows-amd64.sha256
 ...

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 # eth-duties
 
-![python-badge](https://img.shields.io/badge/python-3.10-brightgreen)
-![poetry-badge](https://img.shields.io/badge/poetry-1.3.1-brightgreen)
-![black-badge](https://img.shields.io/badge/black-23.7.0-black)
+![python-badge](https://img.shields.io/badge/python-3.12-brightgreen)
+![poetry-badge](https://img.shields.io/badge/poetry-1.7.1-brightgreen)
+![black-badge](https://img.shields.io/badge/black-23.11.0-black)
 
 ETH-duties logs upcoming validator duties to the console in order to find the best maintenance period for your validator(s). In general the tool was developed to mainly help home stakers but it still can be used on a larger scale.
 

--- a/docs/configuration/general.md
+++ b/docs/configuration/general.md
@@ -16,7 +16,7 @@ For all available cli flags please call `eth-duties --help` or check the table b
 | `--log-color-warning` | The logging color as hex or rgb code for warning logs (default: '255,255,0' - yellow) | [link](./log-colors.md) |
 | `--log-color-critical` | The logging color as hex or rgb code for critical logs (default: '255, 0, 0' - red) | [link](./log-colors.md) |
 | `--log-color-proposing` | The logging color as hex or rgb code for proposing duty logs (default: '0, 128, 0' - green) | [link](./log-colors.md) |
-| `--log-time-warning` | The threshold at which a time to duty warning log (in seconds) will be colored in YELLOW (default: 120) | :no_entry: |
+| `--log-time-warning` | The threshold at which a time to duty warning log (in seconds) will be colored in YELLOW (default: 120) | [link](./log-time.md) |
 | `--log-time-critical` | The threshold at which a time to duty critical log (in seconds) will be colored in RED (default: 60) | :no_entry: |
 | `--max-attestation-duty-logs` | The max. number of validators for which attestation duties will be logged (default: 50) | :no_entry: |
 | `--mode` | The mode which eth-duties will run with. Values are 'log', 'no-log', 'cicd-exit', 'cicd-wait' or 'cicd-force-graceful-exit' (default: 'log') | [link](./mode.md) |

--- a/docs/configuration/log-time.md
+++ b/docs/configuration/log-time.md
@@ -1,0 +1,28 @@
+# Log time
+
+The flag `--log-time-warning` is used as a threshold to color warning logs in a specified color. However, it is also used to log the proportion of all duties which will be executed after `--log-time-warning`. The log includes sync-committee and proposing duties and therefore is different from [--mode-cicd-attestation-time](./mode.md/#mode-cicd-attestation-time-and-mode-cicd-attestation-proportion) which is specific for the cicd modes. The idea is to get some general info on the number of upcoming duties.
+
+## Example
+
+* validator1 is in current sync committee (next sync committe starts in 3h)
+* validator2 is in next sync committee (next sync committe starts in 3h)
+* validator1 has attestation duty in 02:41 min.
+* validator4 has attestation duty in 03:11 min.
+* validator4 has proposing duty in 03:33 min.
+* validator2 has attestation duty in 04:41 min.
+* validator3 has attestation duty in 04:45 min.
+
+```bash
+# Assumed setting:
+./eth-duties --log-time-warning 180 ...
+# The log would be
+71.43% of all duties will be executed in 180.0 sec. or later
+```
+
+```bash
+# Assumed setting:
+./eth-duties --log-time-warning 300 ...
+# The log would be
+14.29% of all duties will be executed in 300.0 sec. or later
+# In this case only the next committee duty will be executed in 300 secs or later
+```


### PR DESCRIPTION
/release

## Summary

This PR leverages the `Taskgroup`, which was introduced in Python 3.11, to send concurrent api calls to the beacon node. Furthermore the documentation was updated which I missed to do in [this PR](https://github.com/TobiWo/eth-duties/pull/65).