### PR TITLE
Update poetry setup and rest api version tag

### DIFF
--- a/duties/rest/app.py
+++ b/duties/rest/app.py
@@ -11,7 +11,7 @@ from uvicorn import Config as UvicornConfig
 app = FastAPI(
     title="eth-duties REST API",
     description="REST endpoints exposed via eth-duties",
-    version="v0.4.0",
+    version="v0.6.0",
 )
 app.include_router(router)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 authors = ["Tobias Wohland <Tobias.Wohland@gmail.com>"]
-description = "Logs upcoming validator duties to the console."
+description = "Log upcoming validator duties to the console."
 license = "MIT"
 name = "eth-duties"
 readme = "README.md"
@@ -10,7 +10,7 @@ version = "0.6.0"
 [tool.poetry.dependencies]
 eth-typing = "==3.5.2"
 fastapi = "==0.104.1"
-python = "==3.12.0"
+python = "~3.12"
 pyyaml = "==6.0.1"
 requests = "==2.31.0"
 sty = "==1.0.4"


### PR DESCRIPTION
## Summary

This PR updates the pyproject.toml so that 'poetry run` will work with all Python 3.12 version. Furthermore the version tag of the rest api was updated.