### PR TITLE
Update format for time to next sync committee

### DIFF
--- a/duties/fetcher/log.py
+++ b/duties/fetcher/log.py
@@ -10,7 +10,10 @@ from cli.arguments import ARGUMENTS
 from constants import logging, program
 from fetcher.data_types import DutyType, ValidatorDuty, ValidatorIdentifier
 from fetcher.identifier.core import read_validator_identifiers_from_shared_memory
-from helper.help import get_duties_proportion_above_time_threshold
+from helper.help import (
+    format_timedelta_to_hours,
+    get_duties_proportion_above_time_threshold,
+)
 from protocol import ethereum
 from sty import bg, rs  # type: ignore[import]
 
@@ -110,8 +113,10 @@ def __create_sync_committee_logging_message(sync_committee_duty: ValidatorDuty) 
     current_sync_committee_epoch_boundaries = (
         ethereum.get_sync_committee_epoch_boundaries(current_epoch)
     )
-    time_to_next_sync_committee = __get_time_to_next_sync_committee(
-        sync_committee_duty, current_sync_committee_epoch_boundaries
+    time_to_next_sync_committee = format_timedelta_to_hours(
+        __get_time_to_next_sync_committee(
+            sync_committee_duty, current_sync_committee_epoch_boundaries
+        )
     )
     if sync_committee_duty.seconds_to_duty == 0:
         logging_message = (

--- a/duties/helper/help.py
+++ b/duties/helper/help.py
@@ -2,6 +2,7 @@
 """
 
 from asyncio import Task, TaskGroup
+from datetime import timedelta
 from multiprocessing.shared_memory import SharedMemory
 from typing import Callable, List
 
@@ -150,6 +151,38 @@ def get_duties_proportion_above_time_threshold(
     ]
     relevant_duty_proportion = len(duties_above_threshold) / len(duties)
     return relevant_duty_proportion
+
+
+def format_timedelta_to_hours(time_delta: timedelta) -> str:
+    """Format a timedelta to HH:MM:SS
+
+    Args:
+        time_delta (timedelta): Timedelta which will be formatted
+
+    Returns:
+        str: Timedelta in format HH:MM:SS
+    """
+
+    def __get_two_digit_time_value(time_value: int) -> str:
+        """Format time integer to two digit string
+
+        Args:
+            time_value (int): Hours, minutes or seconds
+
+        Returns:
+            str: Two digit hours, minutes or seconds
+        """
+        if time_value < 10:
+            return "0" + str(time_value)
+        return str(time_value)
+
+    minutes, seconds = divmod(int(time_delta.total_seconds()), 60)
+    hours, minutes = divmod(minutes, 60)
+    time_values = [hours, minutes, seconds]
+    time_string = ":".join(
+        [__get_two_digit_time_value(time_value) for time_value in time_values]
+    )
+    return time_string
 
 
 __sort_duties: Callable[[ValidatorDuty], int] = lambda duty: duty.slot

--- a/test/cases/test_logging_mode.py
+++ b/test/cases/test_logging_mode.py
@@ -9,6 +9,7 @@ from test_helper.functions import (
     run_generic_test,
     test_set_colorful_logging_thresholds,
     test_standard_logging_mode,
+    test_time_to_next_sync_committee_format,
 )
 from test_helper.general import get_general_eth_duties_start_command
 
@@ -249,3 +250,21 @@ def test_increase_of_max_attestation_duty_logs() -> int:
         "increase of max attestation duty logs",
         "all duties will be executed",
     )
+
+
+def test_logged_format_of_time_to_next_sync_committee() -> int:
+    """Test logging format of time to next sync committee
+
+    Returns:
+        int: Whether or not test succeeds while 1 is success and 0 is failure
+    """
+    command = get_general_eth_duties_start_command(
+        CONFIG.validators.active.in_sync_committee,
+        CONFIG.general.working_beacon_node_url,
+    )
+    try:
+        test_time_to_next_sync_committee_format(command, "duties will be executed")
+        return 1
+    except AssertionError:
+        print(fg.red + "Test Failed" + fg.rs)
+        return 0

--- a/test/run_tests.py
+++ b/test/run_tests.py
@@ -42,6 +42,7 @@ test_cases = [
     test_logging_mode.test_logging_duties_for_high_number_of_validators,
     test_logging_mode.test_omit_attestation_duties,
     test_logging_mode.test_increase_of_max_attestation_duty_logs,
+    test_logging_mode.test_logged_format_of_time_to_next_sync_committee,
     # Test cli validation
     test_cli_validation.test_any_validators_flag_validation,
     test_cli_validation.test_both_validators_flag_validation,

--- a/test/test_helper/functions.py
+++ b/test/test_helper/functions.py
@@ -1,7 +1,7 @@
 """Module containig test function implementations
 """
 
-from re import findall
+from re import findall, search
 from typing import Callable, List
 
 from sty import fg  # type: ignore[import]
@@ -10,6 +10,7 @@ from test_helper.chain import (
     get_number_of_validators_in_current_sync_comittee,
     get_number_of_validators_which_will_propose_block,
 )
+from test_helper.config import CONFIG
 from test_helper.general import compare_logs, print_test_message, run_eth_duties
 
 
@@ -77,6 +78,26 @@ def test_set_colorful_logging_thresholds(
     assert critical_counter == critical_match_counter
     assert warning_counter == warning_match_counter
     print(fg.green + "\rTest succeeded\n" + fg.rs)
+
+
+def test_time_to_next_sync_committee_format(
+    command: List[str], process_termination_log: str
+) -> None:
+    """Test logging format of time to next sync committee
+
+    Args:
+        command (List[str]): eth-duties start command
+        process_termination_log (str): Log which is used to terminate the subprocess
+    """
+    print_test_message(test_message="time logging format to next sync committee")
+    logs = run_eth_duties(command, process_termination_log, None, None)
+    match_counter = 0
+    for log in logs[0]:
+        if "next sync committee starts" in log:
+            match = search("[0-9]+:[0-5][0-9]:[0-5][0-9]\\s/\\sepoch:\\s[0-9]*", log)
+            if match:
+                match_counter += 1
+    assert match_counter == len(CONFIG.validators.active.in_sync_committee)
 
 
 def generic_test(


### PR DESCRIPTION
## Summary

This PR updates the format used to log the time to the next sync committee to `HH:MM:SS`. Currently it will log 26 hours as `1 day, 2 hours` which is not in line with any other upcoming duty logs.

closes #67 