### PR TITLE
Fix sync committee rest response object

### DIFF
--- a/duties/fetcher/data_types.py
+++ b/duties/fetcher/data_types.py
@@ -27,6 +27,7 @@ class ValidatorDuty(BaseModel):
     validator_sync_committee_indices: List[int] = Field(default_factory=list)
     type: DutyType = Field(default=DutyType.NONE)
     seconds_to_duty: int = Field(default=0)
+    seconds_left_in_current_sync_committee: int = Field(default=0)
 
 
 @dataclass

--- a/duties/fetcher/fetch.py
+++ b/duties/fetcher/fetch.py
@@ -2,7 +2,6 @@
 """
 
 from logging import getLogger
-from math import ceil
 from typing import List
 
 from cli.arguments import ARGUMENTS
@@ -60,12 +59,11 @@ async def fetch_upcoming_sync_committee_duties() -> dict[str, ValidatorDuty]:
         for all provided validators
     """
     current_epoch = ethereum.get_current_epoch()
-    next_sync_committee_starting_epoch = (
-        ceil(current_epoch / ethereum.EPOCHS_PER_SYNC_COMMITTEE)
-        * ethereum.EPOCHS_PER_SYNC_COMMITTEE
+    current_sync_committee_epoch_boundaries = (
+        ethereum.get_sync_committee_epoch_boundaries(current_epoch)
     )
     validator_duties: dict[str, ValidatorDuty] = {}
-    for epoch in [current_epoch, next_sync_committee_starting_epoch]:
+    for epoch in [current_epoch, (current_sync_committee_epoch_boundaries[1] + 1)]:
         response_data = await __fetch_duty_responses(epoch, DutyType.SYNC_COMMITTEE)
         for data in response_data:
             if data.validator_index not in validator_duties:

--- a/duties/protocol/ethereum.py
+++ b/duties/protocol/ethereum.py
@@ -1,5 +1,6 @@
 """Defines ethereum related constants and functions
 """
+
 from asyncio import run
 from logging import getLogger
 from math import ceil, trunc
@@ -72,16 +73,20 @@ def set_time_to_duty(duty: ValidatorDuty) -> None:
             current_sync_committee_epoch_boundaries = (
                 get_sync_committee_epoch_boundaries(current_epoch)
             )
+            time_to_next_sync_committee = get_time_to_next_sync_committee(
+                current_sync_committee_epoch_boundaries, current_slot
+            )
             if duty.epoch in range(
                 current_sync_committee_epoch_boundaries[0],
                 current_sync_committee_epoch_boundaries[1] + 1,
                 1,
             ):
                 duty.seconds_to_duty = 0
-            else:
-                duty.seconds_to_duty = get_time_to_next_sync_committee(
-                    current_sync_committee_epoch_boundaries, current_slot
+                duty.seconds_left_in_current_sync_committee = (
+                    time_to_next_sync_committee - 1
                 )
+            else:
+                duty.seconds_to_duty = time_to_next_sync_committee
         case _:
             duty.seconds_to_duty = int(duty.slot * SLOT_TIME + GENESIS_TIME - time())
 


### PR DESCRIPTION
/release

## Summary

This MR fixes the rest api response object for sync committee duties. It adds the property `seconds_left_in_current_sync_committee` which is crucial as this information should not only be retrievable from the logs but also programmatically.